### PR TITLE
feat: add voice status and message list functionality

### DIFF
--- a/schema.go
+++ b/schema.go
@@ -2,6 +2,7 @@ package pocket
 
 import (
 	"encoding/json"
+	"log"
 	"strconv"
 	"time"
 )
@@ -166,4 +167,56 @@ type LiveInfoContent struct {
 	Ctime              string        `json:"ctime"`
 	Announcement       string        `json:"announcement"`
 	SpecialBadge       []interface{} `json:"specialBadge"`
+}
+
+type VoiceUser struct {
+	UserId      int    `json:"userId"`
+	Nickname    string `json:"nickname"`
+	Avatar      string `json:"avatar"`
+	PfUrl       string `json:"pfUrl"`
+	VoiceStatus bool   `json:"voiceStatus"`
+}
+
+type VoiceStatusContent struct {
+	VoiceUserList []VoiceUser `json:"voiceUserList"` // empty for not doing
+	StreamUrl     string      `json:"streamUrl"`     // empty for not doing
+}
+
+type MessageItem struct {
+	MsgIDServer string `json:"msgIdServer"`
+	MsgIDClient string `json:"msgIdClient"`
+	MsgTime     int64  `json:"msgTime"`
+	MsgType     string `json:"msgType"`
+	Bodys       string `json:"bodys"`
+	ExtInfoStr  string `json:"extInfo"`
+	ExtInfo     MessageExtInfo
+}
+
+func (m *MessageItem) FillExtInfo() {
+	var extInfo MessageExtInfo
+	if err := json.Unmarshal([]byte(m.ExtInfoStr), &extInfo); err != nil {
+		log.Println(err)
+	}
+	m.ExtInfo = extInfo
+}
+
+type MessageExtInfo struct {
+	Module      string `json:"module"`
+	ChannelRole string `json:"channelRole"`
+	User        struct {
+		UserId   int    `json:"userId"`
+		NickName string `json:"nickName"`
+		TeamLogo string `json:"teamLogo"`
+		Avatar   string `json:"avatar"`
+		Level    int    `json:"level"`
+		RoleId   int    `json:"roleId"`
+		Vip      bool   `json:"vip"`
+		PfUrl    string `json:"pfUrl"`
+	} `json:"user"`
+	BubbleId string `json:"bubbleId"`
+}
+
+type MessageContent struct {
+	Message  []MessageItem `json:"message"`
+	NextTime int64         `json:"nextTime"` // unix millisecond
 }

--- a/service.go
+++ b/service.go
@@ -29,3 +29,33 @@ func (c *Client) GetLiveInfo(liveId string) (LiveInfoContent, error) {
 	}
 	return content, nil
 }
+
+func (c *Client) GetVoiceStatus(channelId, serverId int) (VoiceStatusContent, error) {
+	content, err := formatter[VoiceStatusContent]{c}.doRestWithResult("", "https://pocketapi.48.cn/im/api/v1/team/voice/operate", map[string]int{
+		"channelId":   channelId,
+		"serverId":    serverId,
+		"operateCode": 2,
+	})
+	if err != nil {
+		return VoiceStatusContent{}, err
+	}
+	return content, nil
+}
+
+func (c *Client) GetMessageList(channelId, serverId int, nextTime int64) ([]MessageItem, int64, error) {
+	content, err := formatter[MessageContent]{c}.doRestWithResult("", "https://pocketapi.48.cn/im/api/v1/team/message/list/homeowner", map[string]any{
+		"channelId": channelId,
+		"serverId":  serverId,
+		"nextTime":  nextTime,
+		"limit":     100,
+	})
+	if err != nil {
+		return nil, 0, err
+	}
+	res := []MessageItem{}
+	for _, msg := range content.Message {
+		msg.FillExtInfo()
+		res = append(res, msg)
+	}
+	return res, content.NextTime, nil
+}

--- a/service_test.go
+++ b/service_test.go
@@ -94,3 +94,68 @@ func TestClient_GetLiveInfo(t *testing.T) {
 		})
 	}
 }
+
+func TestClient_GetVoiceStatus(t *testing.T) {
+	type args struct {
+		channelId int
+		serverId  int
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "normal",
+			args: args{
+				channelId: 1279492,
+				serverId:  1246459,
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := testClient.GetVoiceStatus(tt.args.channelId, tt.args.serverId)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetLiveInfo()")) {
+				return
+			}
+			t.Log(JsonMarshal(got))
+		})
+	}
+}
+
+func TestClient_GetMessageList(t *testing.T) {
+	type args struct {
+		channelId int
+		serverId  int
+		nextTime  int64
+	}
+	tests := []struct {
+		name    string
+		args    args
+		wantErr assert.ErrorAssertionFunc
+	}{
+		{
+			name: "normal",
+			args: args{
+				channelId: 1279492,
+				serverId:  1246459,
+				nextTime:  0,
+			},
+			wantErr: assert.NoError,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages, nextTime, err := testClient.GetMessageList(tt.args.channelId, tt.args.serverId, tt.args.nextTime)
+			if !tt.wantErr(t, err, fmt.Sprintf("GetLiveInfo()")) {
+				return
+			}
+			for i, msg := range messages {
+				t.Log(i, JsonMarshal(msg))
+			}
+			t.Log(nextTime)
+		})
+	}
+}


### PR DESCRIPTION
Implemented new structures and methods to fetch voice status and message lists from the server. This includes the creation of `VoiceUser`, `MessageItem`, and their respective content structures, as well as API calls to retrieve the relevant data and tests to ensure functionality.
